### PR TITLE
v0.2.0 - Censor Sensitive value of environment variable

### DIFF
--- a/eyc/data_source_env_var.go
+++ b/eyc/data_source_env_var.go
@@ -61,8 +61,9 @@ func dataSourceEnvVars() *schema.Resource {
 							Computed: true,
 						},
 						"value": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
 						},
 					},
 				},

--- a/eyc/provider.go
+++ b/eyc/provider.go
@@ -20,6 +20,7 @@ func Provider() *schema.Provider {
 					"EYC_ACCESS_TOKEN",
 				}, nil),
 				Description: "The token key for API operations.",
+				Sensitive:   true,
 			},
 			"api_endpoint": {
 				Type:        schema.TypeString,

--- a/eyc/resource_env_var.go
+++ b/eyc/resource_env_var.go
@@ -73,15 +73,6 @@ func resourceEnvVar() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"name": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"value": &schema.Schema{
-							Type:      schema.TypeString,
-							Computed:  true,
-							Sensitive: true,
-						},
 					},
 				},
 			}},

--- a/eyc/resource_env_var.go
+++ b/eyc/resource_env_var.go
@@ -73,6 +73,15 @@ func resourceEnvVar() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": &schema.Schema{
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
+						},
 					},
 				},
 			}},

--- a/eyc/resource_env_var.go
+++ b/eyc/resource_env_var.go
@@ -36,8 +36,9 @@ func resourceEnvVar() *schema.Resource {
 				Required: true,
 			},
 			"value": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"environment_variable": &schema.Schema{
 				Type:     schema.TypeList,
@@ -77,8 +78,9 @@ func resourceEnvVar() *schema.Resource {
 							Computed: true,
 						},
 						"value": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
 						},
 					},
 				},
@@ -133,7 +135,7 @@ func resourceEnvVarCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 func resourceEnvVarRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*eyc.Client)
-	
+
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 

--- a/eyc/resource_env_var.go
+++ b/eyc/resource_env_var.go
@@ -124,9 +124,9 @@ func resourceEnvVarCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	convertedMapData := make([]interface{}, 0)
 	convertedMapData = append(convertedMapData, mapData["environment_variable"])
 
-	if err := d.Set("environment_variable", convertedMapData); err != nil {
-		return diag.FromErr(err)
-	}
+	// if err := d.Set("environment_variable", convertedMapData); err != nil {
+	// 	return diag.FromErr(err)
+	// }
 
 	d.SetId(strconv.Itoa(body["environment_variable"].ID))
 
@@ -164,9 +164,9 @@ func resourceEnvVarRead(ctx context.Context, d *schema.ResourceData, m interface
 	convertedMapData := make([]interface{}, 0)
 	convertedMapData = append(convertedMapData, mapData["environment_variable"])
 
-	if err := d.Set("environment_variable", convertedMapData); err != nil {
-		return diag.FromErr(err)
-	}
+	// if err := d.Set("environment_variable", convertedMapData); err != nil {
+	// 	return diag.FromErr(err)
+	// }
 	d.Set("value", mapData["environment_variable"]["value"])
 	d.Set("name", mapData["environment_variable"]["name"])
 
@@ -210,9 +210,9 @@ func resourceEnvVarUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 		convertedMapData := make([]interface{}, 0)
 		convertedMapData = append(convertedMapData, mapData["environment_variable"])
 
-		if err := d.Set("environment_variable", convertedMapData); err != nil {
-			return diag.FromErr(err)
-		}
+		// if err := d.Set("environment_variable", convertedMapData); err != nil {
+		// 	return diag.FromErr(err)
+		// }
 		d.Set("last_updated", time.Now().Format(time.RFC850))
 		d.Set("value", mapData["environment_variable"]["value"])
 		d.Set("name", mapData["environment_variable"]["name"])


### PR DESCRIPTION
Before:
Apply:

```
  + resource "eyc_env_var" "env1" {
      + app_id               = 48978
      + env_id               = 130931
      + environment_variable = (known after apply)
      + id                   = (known after apply)
      + last_updated         = (known after apply)
      + name                 = "a"
      + value                = "123"
    }

- Destroy:

```
  # eyc_env_var.env1[0] will be destroyed
  - resource "eyc_env_var" "env1" {
      - app_id               = 48978 -> null
      - env_id               = 130931 -> null
      - environment_variable = [
          - {
              - application      = "https://api.engineyard.com/applications/48978"
              - application_id   = 48978
              - application_name = "frg"
              - environment      = "https://api.engineyard.com/environments/130931"
              - environment_id   = 130931
              - environment_name = "Ey_copy_frg_staging"
              - id               = 7557
              - name             = "a"
              - value            = "123"
            },
        ] -> null
      - id                   = "7557" -> null
      - name                 = "a" -> null
      - value                = (sensitive value)
    }
```

  # eyc_env_var.env1[1] will be created
  + resource "eyc_env_var" "env1" {
      + app_id               = 48978
      + env_id               = 130931
      + environment_variable = (known after apply)
      + id                   = (known after apply)
      + last_updated         = (known after apply)
      + name                 = "b"
      + value                = "2"
    }
```

After:

Apply:

<img width="469" alt="image" src="https://user-images.githubusercontent.com/55923773/202674656-91c7de33-06d6-488c-b5d7-6e282883e40f.png">


Destroy:

```
  # eyc_env_var.env1[0] will be destroyed
  - resource "eyc_env_var" "env1" {
      - app_id = 48978 -> null
      - env_id = 130931 -> null
      - id     = "7566" -> null
      - name   = "a" -> null
      - value  = (sensitive value)
    }

  # eyc_env_var.env1[1] will be destroyed
  - resource "eyc_env_var" "env1" {
      - app_id = 48978 -> null
      - env_id = 130931 -> null
      - id     = "7567" -> null
      - name   = "b" -> null
      - value  = (sensitive value)
    }
```
