### PR TITLE
Fix Apply Idempotency

### DIFF
--- a/eyc/resource_env_var.go
+++ b/eyc/resource_env_var.go
@@ -40,51 +40,7 @@ func resourceEnvVar() *schema.Resource {
 				Required:  true,
 				Sensitive: true,
 			},
-			"environment_variable": &schema.Schema{
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": &schema.Schema{
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"application": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"application_id": &schema.Schema{
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"application_name": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"environment": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"environment_id": &schema.Schema{
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"environment_name": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"name": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"value": &schema.Schema{
-							Type:      schema.TypeString,
-							Computed:  true,
-							Sensitive: true,
-						},
-					},
-				},
-			}},
+		},
 	}
 }
 


### PR DESCRIPTION
Issue: subsequent apply still detect changes despite nothing changes from configuration

```
  ~ resource "eyc_env_var" "env1" {
      + environment_variable = (known after apply)
        id                   = "7590"
        name                 = "b"
        # (3 unchanged attributes hidden)
    }
```

Why: Unnecessary Computed environment_variable attribute from schema